### PR TITLE
JMK_102: Fetching Proposals submitted by specific job posting id

### DIFF
--- a/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
@@ -2,7 +2,6 @@ package com.jobmatrix.jm_proposal.controller;
 
 import com.common.enums.ProposalStatus;
 import com.common.util.EnumUtils;
-import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.jobmatrix.jm_proposal.service.ProposalService;
@@ -28,6 +27,13 @@ public class ProposalController {
         ProposalSubmission savedProposal = proposalService.submitProposal(proposalRequest);
         return new ResponseEntity<>(savedProposal, HttpStatus.CREATED);
     }
+
+    @GetMapping("/{jobPostingId}")
+    public ResponseEntity<ProposalSubmission> getProposalByJobPostingId(@PathVariable Long jobPostingId) {
+        ProposalSubmission proposal = proposalService.getProposalByJobPostingId(jobPostingId);
+        return ResponseEntity.ok(proposal);
+    }
+
 
     @GetMapping("/{freelancerId}/statuses/{statuses}")
     public ResponseEntity<Map<ProposalStatus, List<ProposalSubmissionDTO>>> getProposalsByFreelancerId(

--- a/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
@@ -6,20 +6,26 @@ import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.jobmatrix.jm_proposal.service.ProposalService;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
-
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 
 @RestController
 @RequestMapping("/api/v1/proposals")
 @RequiredArgsConstructor
 public class ProposalController {
     private final ProposalService proposalService;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
 
     @PostMapping("/create_proposal")
     public ResponseEntity<ProposalSubmission> submitProposal(
@@ -29,8 +35,8 @@ public class ProposalController {
     }
 
     @GetMapping("/{jobPostingId}")
-    public ResponseEntity<ProposalSubmission> getProposalByJobPostingId(@PathVariable Long jobPostingId) {
-        ProposalSubmission proposal = proposalService.getProposalByJobPostingId(jobPostingId);
+    public ResponseEntity<ProposalSubmissionDTO> getProposalByJobPostingId(@PathVariable Long jobPostingId) {
+        ProposalSubmissionDTO proposal = proposalService.getProposalByJobPostingId(jobPostingId);
         return ResponseEntity.ok(proposal);
     }
 

--- a/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
@@ -6,8 +6,6 @@ import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.jobmatrix.jm_proposal.service.ProposalService;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,9 +29,9 @@ public class ProposalController {
     }
 
     @GetMapping("/{jobPostingId}")
-    public ResponseEntity<ProposalSubmissionDTO> getProposalByJobPostingId(@PathVariable Long jobPostingId) {
-        ProposalSubmissionDTO proposal = proposalService.getProposalByJobPostingId(jobPostingId);
-        return ResponseEntity.ok(proposal);
+    public ResponseEntity<List<ProposalSubmissionDTO>> getProposalsByJobPostingId(@PathVariable Long jobPostingId) {
+        List<ProposalSubmissionDTO> proposals = proposalService.getProposalsByJobPostingId(jobPostingId);
+        return ResponseEntity.ok(proposals);
     }
 
     @GetMapping("/{freelancerId}/statuses/{statuses}")

--- a/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
@@ -23,10 +23,6 @@ import java.util.UUID;
 public class ProposalController {
     private final ProposalService proposalService;
 
-    @Autowired
-    private ModelMapper modelMapper;
-
-
     @PostMapping("/create_proposal")
     public ResponseEntity<ProposalSubmission> submitProposal(
             @Valid @RequestBody ProposalSubmissionDTO proposalRequest) {
@@ -39,7 +35,6 @@ public class ProposalController {
         ProposalSubmissionDTO proposal = proposalService.getProposalByJobPostingId(jobPostingId);
         return ResponseEntity.ok(proposal);
     }
-
 
     @GetMapping("/{freelancerId}/statuses/{statuses}")
     public ResponseEntity<Map<ProposalStatus, List<ProposalSubmissionDTO>>> getProposalsByFreelancerId(

--- a/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalSubmissionDTO.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalSubmissionDTO.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 public class ProposalSubmissionDTO {
 
     @NotNull(message = "Job Posting ID is required")
-    private int jobPostingId;
+    private long jobPostingId;
 
     @NotNull(message = "Freelancer ID is required")
     private UUID freelancerId;

--- a/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalSubmissionDTO.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalSubmissionDTO.java
@@ -5,9 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.*;
-
-import java.math.BigDecimal;
-import java.util.List;
 import java.util.UUID;
 
 @Data

--- a/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
@@ -10,8 +10,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcType;
 import org.hibernate.annotations.UpdateTimestamp;
-
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 

--- a/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
@@ -1,6 +1,5 @@
 package com.jobmatrix.jm_proposal.entity;
 
-
 import com.common.enums.ProposalStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,11 +41,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ProposalNotFoundException.class)
     public ResponseEntity<Object> handleProposalNotFoundException(ProposalNotFoundException ex) {
         Map<String, Object> errorBody = new HashMap<>();
-        errorBody.put("timestamp", LocalDateTime.now());
-        errorBody.put("status", HttpStatus.NOT_FOUND.value());
-        errorBody.put("error", "Not Found");
         errorBody.put("message", ex.getMessage());
-
         return new ResponseEntity<>(errorBody, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
@@ -49,6 +49,4 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(errorBody, HttpStatus.NOT_FOUND);
     }
-
-
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
@@ -38,4 +38,17 @@ public class GlobalExceptionHandler {
         errorResponse.put("message", ex.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(ProposalNotFoundException.class)
+    public ResponseEntity<Object> handleProposalNotFoundException(ProposalNotFoundException ex) {
+        Map<String, Object> errorBody = new HashMap<>();
+        errorBody.put("timestamp", LocalDateTime.now());
+        errorBody.put("status", HttpStatus.NOT_FOUND.value());
+        errorBody.put("error", "Not Found");
+        errorBody.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(errorBody, HttpStatus.NOT_FOUND);
+    }
+
+
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/ProposalNotFoundException.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/ProposalNotFoundException.java
@@ -1,6 +1,6 @@
 package com.jobmatrix.jm_proposal.exception;
 
-import java.util.UUID;
+
 
 public class ProposalNotFoundException extends RuntimeException {
     public ProposalNotFoundException(Long jobPostingId) {

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/ProposalNotFoundException.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/ProposalNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jobmatrix.jm_proposal.exception;
+
+public class ProposalNotFoundException extends RuntimeException {
+    public ProposalNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/ProposalNotFoundException.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/ProposalNotFoundException.java
@@ -1,7 +1,9 @@
 package com.jobmatrix.jm_proposal.exception;
 
+import java.util.UUID;
+
 public class ProposalNotFoundException extends RuntimeException {
-    public ProposalNotFoundException(String message) {
-        super(message);
+    public ProposalNotFoundException(Long jobPostingId) {
+        super("Proposal not found for job posting ID: " + jobPostingId);
     }
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/repository/ProposalRepository.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/repository/ProposalRepository.java
@@ -6,9 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface ProposalRepository extends JpaRepository<ProposalSubmission, Long> {
     List<ProposalSubmission> findByFreelancerIdAndProposalStatus(UUID freelancerId, ProposalStatus proposalStatus);
+    Optional<ProposalSubmission> findByJobPostingId(Long jobPostingId);
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/repository/ProposalRepository.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/repository/ProposalRepository.java
@@ -1,6 +1,7 @@
 package com.jobmatrix.jm_proposal.repository;
 
 import com.common.enums.ProposalStatus;
+import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,5 +13,5 @@ import java.util.UUID;
 @Repository
 public interface ProposalRepository extends JpaRepository<ProposalSubmission, Long> {
     List<ProposalSubmission> findByFreelancerIdAndProposalStatus(UUID freelancerId, ProposalStatus proposalStatus);
-    Optional<ProposalSubmission> findByJobPostingId(Long jobPostingId);
+    List<ProposalSubmission> findByJobPostingIdAndProposalStatusOrderByCreatedAtDesc(Long jobPostingId, ProposalStatus proposalStatus);
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
@@ -13,5 +13,5 @@ public interface ProposalService {
 
     Map<ProposalStatus, List<ProposalSubmissionDTO>> getProposalsByStatus(UUID freelancerId, List<ProposalStatus> statusList);
 
-    ProposalSubmission getProposalByJobPostingId(Long jobPostingId);
+    ProposalSubmissionDTO getProposalByJobPostingId(Long jobPostingId);
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
@@ -13,5 +13,5 @@ public interface ProposalService {
 
     Map<ProposalStatus, List<ProposalSubmissionDTO>> getProposalsByStatus(UUID freelancerId, List<ProposalStatus> statusList);
 
-    ProposalSubmissionDTO getProposalByJobPostingId(Long jobPostingId);
+    List<ProposalSubmissionDTO> getProposalsByJobPostingId(Long jobPostingId);
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
@@ -12,4 +12,6 @@ public interface ProposalService {
     ProposalSubmission submitProposal(ProposalSubmissionDTO proposalRequest);
 
     Map<ProposalStatus, List<ProposalSubmissionDTO>> getProposalsByStatus(UUID freelancerId, List<ProposalStatus> statusList);
+
+    ProposalSubmission getProposalByJobPostingId(Long jobPostingId);
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -13,6 +13,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -48,15 +49,11 @@ public class ProposalServiceImpl implements ProposalService {
         return result;
     }
     @Override
-    public ProposalSubmissionDTO getProposalByJobPostingId(Long jobPostingId)
-    {
-        ProposalSubmission proposal = proposalRepository.findByJobPostingId(jobPostingId)
-                .orElseThrow(() -> new ProposalNotFoundException(jobPostingId));
-
-        if (proposal.getProposalStatus() != ProposalStatus.SUBMITTED) {
+    public List<ProposalSubmissionDTO> getProposalsByJobPostingId(Long jobPostingId) {
+        List<ProposalSubmission> proposals = proposalRepository.findByJobPostingIdAndProposalStatusOrderByCreatedAtDesc(jobPostingId, ProposalStatus.SUBMITTED);
+        if (proposals.isEmpty()) {
             throw new ProposalNotFoundException(jobPostingId);
         }
-
-        return modelMapper.map(proposal, ProposalSubmissionDTO.class);
+        return proposals.stream().map(proposal -> modelMapper.map(proposal, ProposalSubmissionDTO.class)).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -48,10 +48,17 @@ public class ProposalServiceImpl implements ProposalService {
         }
         return result;
     }
-
     @Override
-    public ProposalSubmission getProposalByJobPostingId(Long jobPostingId) {
-        return proposalRepository.findByJobPostingId(jobPostingId)
-                .orElseThrow(() -> new ProposalNotFoundException("Proposal not found for job posting ID: " + jobPostingId));
+    public ProposalSubmissionDTO getProposalByJobPostingId(Long jobPostingId)
+    {
+        ProposalSubmission proposal = proposalRepository.findByJobPostingId(jobPostingId)
+                .orElseThrow(() -> new ProposalNotFoundException(jobPostingId));
+
+        if (proposal.getProposalStatus() != ProposalStatus.SUBMITTED) {
+            throw new ProposalNotFoundException(jobPostingId);
+        }
+
+        return modelMapper.map(proposal, ProposalSubmissionDTO.class);
     }
+
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -4,6 +4,7 @@ import com.common.enums.ProposalStatus;
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
+import com.jobmatrix.jm_proposal.exception.ProposalNotFoundException;
 import com.jobmatrix.jm_proposal.repository.FreelancerRepository;
 import com.jobmatrix.jm_proposal.repository.ProposalRepository;
 import com.jobmatrix.jm_proposal.service.ProposalService;
@@ -48,4 +49,9 @@ public class ProposalServiceImpl implements ProposalService {
         return result;
     }
 
+    @Override
+    public ProposalSubmission getProposalByJobPostingId(Long jobPostingId) {
+        return proposalRepository.findByJobPostingId(jobPostingId)
+                .orElseThrow(() -> new ProposalNotFoundException("Proposal not found for job posting ID: " + jobPostingId));
+    }
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.*;
 
 @Service
@@ -60,5 +59,4 @@ public class ProposalServiceImpl implements ProposalService {
 
         return modelMapper.map(proposal, ProposalSubmissionDTO.class);
     }
-
 }

--- a/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -31,6 +32,9 @@ class ProposalControllerTest {
     private MockMvc mockMvc;
 
     @MockitoBean
+    private ModelMapper modelMapper;
+
+    @MockitoBean
     private ProposalService proposalService;
 
     @Autowired
@@ -48,34 +52,6 @@ class ProposalControllerTest {
     }
 
 
-
-    @Test
-    void submitProposal_returnsCreatedProposal() throws Exception {
-        when(proposalService.submitProposal(ArgumentMatchers.any(ProposalSubmissionDTO.class)))
-                .thenReturn(savedProposal);
-
-        mockMvc.perform(post("/api/v1/proposals/create_proposal")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.proposalId").value(savedProposal.getProposalId()))
-                .andExpect(jsonPath("$.jobPostingId").value(savedProposal.getJobPostingId()))
-                .andExpect(jsonPath("$.coverLetter").value(savedProposal.getCoverLetter()));
-    }
-
-    @Test
-    void getProposalById_shouldReturnProposal_whenExists() throws Exception
-    {
-        Long jobPostingId = 1L;
-        when(proposalService.getProposalByJobPostingId(jobPostingId))
-                .thenReturn(savedProposal);
-
-        mockMvc.perform(get("/api/v1/proposals/{jobPostingId}", jobPostingId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.proposalId").value(savedProposal.getProposalId()))
-                .andExpect(jsonPath("$.jobPostingId").value(savedProposal.getJobPostingId()))
-                .andExpect(jsonPath("$.coverLetter").value(savedProposal.getCoverLetter()));
-    }
     @Test
     void submitProposal_missingCoverLetter_returnsBadRequest() throws Exception {
         requestDto.setCoverLetter(""); // invalid: @NotBlank violation
@@ -112,6 +88,27 @@ class ProposalControllerTest {
                 .andExpect(jsonPath("$.SUBMITTED[0].jobPostingId").value(JOB_POSTING_ID))
                 .andExpect(jsonPath("$.ACCEPTED[0].jobPostingId").value(JOB_POSTING_ID));
     }
+
+    @Test
+    void getProposalByJobPostingId_shouldReturnProposal_whenExists() throws Exception {
+        Long jobPostingId = 101L;
+        UUID freelancerId = UUID.randomUUID();
+        UUID clientId = UUID.randomUUID();
+
+        ProposalSubmissionDTO proposalDTO = ProposalTestDataFactory.createProposalSubmissionRequest(freelancerId, clientId);
+        proposalDTO.setJobPostingId(jobPostingId);
+        proposalDTO.setProposalStatus(ProposalStatus.SUBMITTED);
+
+        when(proposalService.getProposalByJobPostingId(jobPostingId)).thenReturn(proposalDTO);
+
+        mockMvc.perform(get("/api/v1/proposals/{jobPostingId}", jobPostingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.jobPostingId").value(jobPostingId))
+                .andExpect(jsonPath("$.freelancerId").value(freelancerId.toString()))
+                .andExpect(jsonPath("$.clientId").value(clientId.toString()))
+                .andExpect(jsonPath("$.proposalStatus").value(ProposalStatus.SUBMITTED.toString()));
+    }
+
 
     @Test
     void getProposalsByStatuses_EmptyResult() throws Exception {

--- a/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
@@ -7,6 +7,7 @@ import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.jobmatrix.jm_proposal.service.ProposalService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +17,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import java.util.*;
-
 import com.jobmatrix.jm_proposal.test_utils.factory.ProposalTestDataFactory;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -61,6 +61,19 @@ class ProposalControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.coverLetter").value("Cover letter is required"));
     }
+    @Test
+    void submitProposal_returnsCreatedProposal() throws Exception {
+        when(proposalService.submitProposal(ArgumentMatchers.any(ProposalSubmissionDTO.class)))
+                .thenReturn(savedProposal);
+
+        mockMvc.perform(post("/api/v1/proposals/create_proposal")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.proposalId").value(savedProposal.getProposalId()))
+                .andExpect(jsonPath("$.jobPostingId").value(savedProposal.getJobPostingId()))
+                .andExpect(jsonPath("$.coverLetter").value(savedProposal.getCoverLetter()));
+    }
 
     @Test
     void getProposalsByStatus() throws Exception {
@@ -87,27 +100,23 @@ class ProposalControllerTest {
                 .andExpect(jsonPath("$.SUBMITTED[0].jobPostingId").value(JOB_POSTING_ID))
                 .andExpect(jsonPath("$.ACCEPTED[0].jobPostingId").value(JOB_POSTING_ID));
     }
-
     @Test
-    void getProposalByJobPostingId_shouldReturnProposal_whenExists() throws Exception {
-        Long jobPostingId = 101L;
+    void getProposalsByJobPostingId_shouldReturnProposals_whenExists() throws Exception {
         UUID freelancerId = UUID.randomUUID();
         UUID clientId = UUID.randomUUID();
+        Long jobPostingId = 1L;
 
-        ProposalSubmissionDTO proposalDTO = ProposalTestDataFactory.createProposalSubmissionRequest(freelancerId, clientId);
-        proposalDTO.setJobPostingId(jobPostingId);
-        proposalDTO.setProposalStatus(ProposalStatus.SUBMITTED);
+        ProposalSubmissionDTO dto = ProposalSubmissionDTO.builder()
+                .jobPostingId(jobPostingId)
+                .freelancerId(freelancerId)
+                .clientId(clientId)
+                .proposalStatus(ProposalStatus.SUBMITTED)
+                .build();
 
-        when(proposalService.getProposalByJobPostingId(jobPostingId)).thenReturn(proposalDTO);
+        when(proposalService.getProposalsByJobPostingId(jobPostingId))
+                .thenReturn(Collections.singletonList(dto));
 
-        mockMvc.perform(get("/api/v1/proposals/{jobPostingId}", jobPostingId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.jobPostingId").value(jobPostingId))
-                .andExpect(jsonPath("$.freelancerId").value(freelancerId.toString()))
-                .andExpect(jsonPath("$.clientId").value(clientId.toString()))
-                .andExpect(jsonPath("$.proposalStatus").value(ProposalStatus.SUBMITTED.toString()));
     }
-
 
     @Test
     void getProposalsByStatuses_EmptyResult() throws Exception {

--- a/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
@@ -7,7 +7,6 @@ import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.jobmatrix.jm_proposal.service.ProposalService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
@@ -101,7 +101,7 @@ class ProposalControllerTest {
                 .andExpect(jsonPath("$.ACCEPTED[0].jobPostingId").value(JOB_POSTING_ID));
     }
     @Test
-    void getProposalsByJobPostingId_shouldReturnProposals_whenExists() throws Exception {
+    void getProposalsByJobPostingId_shouldReturnSubmittedProposals_whenExists() throws Exception {
         UUID freelancerId = UUID.randomUUID();
         UUID clientId = UUID.randomUUID();
         Long jobPostingId = 1L;

--- a/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/controller/ProposalControllerTest.java
@@ -5,7 +5,6 @@ import com.common.enums.ProposalStatus;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.jobmatrix.jm_proposal.service.ProposalService;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -15,17 +14,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.http.HttpStatus;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.hamcrest.Matchers.containsString;
-
 import java.util.*;
 
 import com.jobmatrix.jm_proposal.test_utils.factory.ProposalTestDataFactory;
-import com.common.enums.ProposalStatus;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -72,6 +64,19 @@ class ProposalControllerTest {
     }
 
     @Test
+    void getProposalById_shouldReturnProposal_whenExists() throws Exception
+    {
+        Long jobPostingId = 1L;
+        when(proposalService.getProposalByJobPostingId(jobPostingId))
+                .thenReturn(savedProposal);
+
+        mockMvc.perform(get("/api/v1/proposals/{jobPostingId}", jobPostingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.proposalId").value(savedProposal.getProposalId()))
+                .andExpect(jsonPath("$.jobPostingId").value(savedProposal.getJobPostingId()))
+                .andExpect(jsonPath("$.coverLetter").value(savedProposal.getCoverLetter()));
+    }
+    @Test
     void submitProposal_missingCoverLetter_returnsBadRequest() throws Exception {
         requestDto.setCoverLetter(""); // invalid: @NotBlank violation
 
@@ -85,14 +90,14 @@ class ProposalControllerTest {
     @Test
     void getProposalsByStatus() throws Exception {
         UUID freelancerId = UUID.randomUUID();
-        
+
         ProposalSubmissionDTO draftProposalDTO = ProposalTestDataFactory.createProposalSubmissionRequest(freelancerId, freelancerId);
         ProposalSubmissionDTO openProposalDTO = ProposalTestDataFactory.createProposalSubmissionRequest(freelancerId, freelancerId);
         openProposalDTO.setProposalStatus(ProposalStatus.ACCEPTED);
 
         Map<ProposalStatus, List<ProposalSubmissionDTO>> mockResult = Map.of(
-            ProposalStatus.SUBMITTED, List.of(draftProposalDTO),
-            ProposalStatus.ACCEPTED, List.of(openProposalDTO)
+                ProposalStatus.SUBMITTED, List.of(draftProposalDTO),
+                ProposalStatus.ACCEPTED, List.of(openProposalDTO)
         );
 
         when(proposalService.getProposalsByStatus(

--- a/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
@@ -54,30 +54,21 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void handleProposalNotFoundException_shouldReturnNotFoundResponse() {
+    void handleProposalNotFoundException_shouldReturnNotFoundErrorBody() {
         // Arrange
-        String errorMessage = "Proposal not found for job posting ID: 123";
-        ProposalNotFoundException exception = new ProposalNotFoundException(errorMessage);
+        Long jobPostingId = 123L;
+        ProposalNotFoundException exception = new ProposalNotFoundException(jobPostingId);
 
         // Act
         ResponseEntity<Object> response = exceptionHandler.handleProposalNotFoundException(exception);
 
         // Assert
-        assertNotNull(response);
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-
-        Object responseBody = response.getBody();
-        assertNotNull(responseBody);
-        assertTrue(responseBody instanceof Map);
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> errorMap = (Map<String, Object>) responseBody;
-
-        assertEquals(404, errorMap.get("status"));
-        assertEquals("Not Found", errorMap.get("error"));
-        assertEquals(errorMessage, errorMap.get("message"));
-        assertNotNull(errorMap.get("timestamp")); // timestamp should be present
+        assertEquals(404, response.getStatusCodeValue());
+        assertTrue(response.getBody() instanceof Map);
+        Map<String, Object> errorBody = (Map<String, Object>) response.getBody();
+        assertEquals("Not Found", errorBody.get("error"));
+        assertEquals("Proposal not found for job posting ID: " + jobPostingId, errorBody.get("message"));
     }
 
-
 }
+

--- a/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package com.jobmatrix.jm_proposal.exception;
 
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -21,12 +22,9 @@ class GlobalExceptionHandlerTest {
         BindingResult bindingResult = new BindException(new Object(), "proposalSubmissionRequest");
         bindingResult.addError(new FieldError("proposalSubmissionRequest", "coverLetter", "Cover letter is required"));
         bindingResult.addError(new FieldError("proposalSubmissionRequest", "proposedBidAmount", "Bid amount must be positive"));
-
         MethodArgumentNotValidException exception = new MethodArgumentNotValidException(null, bindingResult);
-
         // Act
         ResponseEntity<Map<String, String>> response = exceptionHandler.handleValidationExceptions(exception);
-
         // Assert
         assertEquals(400, response.getStatusCodeValue());
 
@@ -43,30 +41,26 @@ class GlobalExceptionHandlerTest {
         UUID freelancerId = UUID.randomUUID();
         FreelancerNotFoundException exception = new FreelancerNotFoundException(freelancerId);
         String expectedMessage = "Freelancer not found with ID: " + freelancerId;
-
         // Act
         ResponseEntity<String> response = exceptionHandler.handleFreelancerNotFoundException(exception);
-
         // Assert
         assertEquals(404, response.getStatusCodeValue());
         assertEquals(expectedMessage, response.getBody());
     }
 
     @Test
-    void handleProposalNotFoundException_shouldReturnNotFoundErrorBody() {
-        // Arrange
+    void testHandleProposalNotFoundException() {
+        // Given
         Long jobPostingId = 123L;
         ProposalNotFoundException exception = new ProposalNotFoundException(jobPostingId);
-
-        // Act
+        // When
         ResponseEntity<Object> response = exceptionHandler.handleProposalNotFoundException(exception);
-
-        // Assert
-        assertEquals(404, response.getStatusCodeValue());
+        // Then
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNotNull(response.getBody());
         assertTrue(response.getBody() instanceof Map);
-        Map<String, Object> errorBody = (Map<String, Object>) response.getBody();
-        assertEquals("Not Found", errorBody.get("error"));
-        assertEquals("Proposal not found for job posting ID: " + jobPostingId, errorBody.get("message"));
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertEquals("Proposal not found for job posting ID: 123", body.get("message"));
     }
 }
 

--- a/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
@@ -2,7 +2,6 @@ package com.jobmatrix.jm_proposal.exception;
 
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -69,6 +68,5 @@ class GlobalExceptionHandlerTest {
         assertEquals("Not Found", errorBody.get("error"));
         assertEquals("Proposal not found for job posting ID: " + jobPostingId, errorBody.get("message"));
     }
-
 }
 

--- a/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
@@ -1,26 +1,16 @@
 package com.jobmatrix.jm_proposal.exception;
 
 import com.common.exceptionHandling.FreelancerNotFoundException;
-import com.common.exceptionHandling.InvalidEnumValueException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.never;
 
 class GlobalExceptionHandlerTest {
 
@@ -53,7 +43,7 @@ class GlobalExceptionHandlerTest {
         // Arrange
         UUID freelancerId = UUID.randomUUID();
         FreelancerNotFoundException exception = new FreelancerNotFoundException(freelancerId);
-        String expectedMessage = "Freelancer not found with Freelancer ID: " + freelancerId;
+        String expectedMessage = "Freelancer not found with ID: " + freelancerId;
 
         // Act
         ResponseEntity<String> response = exceptionHandler.handleFreelancerNotFoundException(exception);
@@ -62,5 +52,32 @@ class GlobalExceptionHandlerTest {
         assertEquals(404, response.getStatusCodeValue());
         assertEquals(expectedMessage, response.getBody());
     }
+
+    @Test
+    void handleProposalNotFoundException_shouldReturnNotFoundResponse() {
+        // Arrange
+        String errorMessage = "Proposal not found for job posting ID: 123";
+        ProposalNotFoundException exception = new ProposalNotFoundException(errorMessage);
+
+        // Act
+        ResponseEntity<Object> response = exceptionHandler.handleProposalNotFoundException(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        Object responseBody = response.getBody();
+        assertNotNull(responseBody);
+        assertTrue(responseBody instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> errorMap = (Map<String, Object>) responseBody;
+
+        assertEquals(404, errorMap.get("status"));
+        assertEquals("Not Found", errorMap.get("error"));
+        assertEquals(errorMessage, errorMap.get("message"));
+        assertNotNull(errorMap.get("timestamp")); // timestamp should be present
+    }
+
 
 }

--- a/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.jobmatrix.jm_proposal.serviceimpl;
 
-import com.common.entity.Freelancer;
+
 import com.common.enums.ProposalStatus;
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
@@ -11,16 +11,11 @@ import com.jobmatrix.jm_proposal.test_utils.factory.ProposalTestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
-import java.util.UUID;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,9 +70,32 @@ class ProposalServiceImplTest {
 
         verify(proposalRepository).save(any(ProposalSubmission.class));
     }
+    @Test
+    void getProposalByJobPostingId_Success() {
+        // Given
+        Long jobPostingId = 101L;
+        UUID freelancerId = UUID.randomUUID();
+        UUID clientId = UUID.randomUUID();
+
+        ProposalSubmission proposal = ProposalTestDataFactory.createProposalEntity(jobPostingId, freelancerId, clientId);
+
+        when(proposalRepository.findByJobPostingId(jobPostingId)).thenReturn(Optional.of(proposal));
+
+        // When
+        ProposalSubmission result = proposalService.getProposalByJobPostingId(jobPostingId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(jobPostingId, result.getJobPostingId());
+        assertEquals(freelancerId, result.getFreelancerId());
+        assertEquals(clientId, result.getClientId());
+
+        verify(proposalRepository, times(1)).findByJobPostingId(jobPostingId);
+    }
 
     @Test
     void getProposalsByStatuses_Success() {
+
         // given
         UUID freelancerId = UUID.randomUUID();
         List<ProposalStatus> statuses = Arrays.asList(ProposalStatus.SUBMITTED, ProposalStatus.ACCEPTED);
@@ -188,7 +206,7 @@ class ProposalServiceImplTest {
             () -> proposalService.getProposalsByStatus(freelancerId, statuses)
         );
         
-        assertEquals("Freelancer not found with Freelancer ID: " + freelancerId, exception.getMessage());
+        assertEquals("Freelancer not found with ID: " + freelancerId, exception.getMessage());
         
         verify(freelancerRepository).existsById(freelancerId);
         verifyNoMoreInteractions(proposalRepository);

--- a/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.jobmatrix.jm_proposal.serviceimpl;
 
-
 import com.common.enums.ProposalStatus;
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
-
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -210,6 +208,4 @@ class ProposalServiceImplTest {
         verify(freelancerRepository).existsById(freelancerId);
         verifyNoMoreInteractions(proposalRepository);
     }
-
-
 }

--- a/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
@@ -69,26 +69,31 @@ class ProposalServiceImplTest {
         verify(proposalRepository).save(any(ProposalSubmission.class));
     }
     @Test
-    void getProposalByJobPostingId_shouldReturnProposal_whenExists() {
+    void getProposalsByJobPostingId_shouldReturnListOfSubmittedProposalsSortedByCreatedAtDesc() {
         Long jobPostingId = 1L;
         UUID freelancerId = UUID.randomUUID();
         UUID clientId = UUID.randomUUID();
 
-        ProposalSubmission proposal = ProposalTestDataFactory.createTestProposal(jobPostingId, freelancerId, clientId);
-        proposal.setProposalStatus(ProposalStatus.SUBMITTED);
+        ProposalSubmission proposal1 = ProposalTestDataFactory.createTestProposal(jobPostingId, freelancerId, clientId);
+        proposal1.setProposalStatus(ProposalStatus.SUBMITTED);
 
-        when(proposalRepository.findByJobPostingId(jobPostingId)).thenReturn(Optional.of(proposal));
+        ProposalSubmission proposal2 = ProposalTestDataFactory.createTestProposal(jobPostingId, freelancerId, clientId);
+        proposal2.setProposalStatus(ProposalStatus.SUBMITTED);
 
-        ProposalSubmissionDTO result = proposalService.getProposalByJobPostingId(jobPostingId);
+
+        List<ProposalSubmission> mockProposals = List.of(proposal2, proposal1); // Sorted: most recent first
+
+        when(proposalRepository.findByJobPostingIdAndProposalStatusOrderByCreatedAtDesc(jobPostingId, ProposalStatus.SUBMITTED))
+                .thenReturn(mockProposals);
+
+        List<ProposalSubmissionDTO> result = proposalService.getProposalsByJobPostingId(jobPostingId);
 
         assertNotNull(result);
-        assertEquals(jobPostingId, result.getJobPostingId());
-        assertEquals(freelancerId, result.getFreelancerId());
-        assertEquals(clientId, result.getClientId());
-        assertEquals(ProposalStatus.SUBMITTED, result.getProposalStatus());
+        assertEquals(2, result.size());
 
-        verify(proposalRepository).findByJobPostingId(jobPostingId);
+        verify(proposalRepository).findByJobPostingIdAndProposalStatusOrderByCreatedAtDesc(jobPostingId, ProposalStatus.SUBMITTED);
     }
+
 
     @Test
     void getProposalsByStatuses_Success() {

--- a/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
@@ -71,26 +71,25 @@ class ProposalServiceImplTest {
         verify(proposalRepository).save(any(ProposalSubmission.class));
     }
     @Test
-    void getProposalByJobPostingId_Success() {
-        // Given
-        Long jobPostingId = 101L;
+    void getProposalByJobPostingId_shouldReturnProposal_whenExists() {
+        Long jobPostingId = 1L;
         UUID freelancerId = UUID.randomUUID();
         UUID clientId = UUID.randomUUID();
 
-        ProposalSubmission proposal = ProposalTestDataFactory.createProposalEntity(jobPostingId, freelancerId, clientId);
+        ProposalSubmission proposal = ProposalTestDataFactory.createTestProposal(jobPostingId, freelancerId, clientId);
+        proposal.setProposalStatus(ProposalStatus.SUBMITTED);
 
         when(proposalRepository.findByJobPostingId(jobPostingId)).thenReturn(Optional.of(proposal));
 
-        // When
-        ProposalSubmission result = proposalService.getProposalByJobPostingId(jobPostingId);
+        ProposalSubmissionDTO result = proposalService.getProposalByJobPostingId(jobPostingId);
 
-        // Then
         assertNotNull(result);
         assertEquals(jobPostingId, result.getJobPostingId());
         assertEquals(freelancerId, result.getFreelancerId());
         assertEquals(clientId, result.getClientId());
+        assertEquals(ProposalStatus.SUBMITTED, result.getProposalStatus());
 
-        verify(proposalRepository, times(1)).findByJobPostingId(jobPostingId);
+        verify(proposalRepository).findByJobPostingId(jobPostingId);
     }
 
     @Test

--- a/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
@@ -4,7 +4,6 @@ import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.common.enums.ProposalStatus;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -46,6 +45,7 @@ public class ProposalTestDataFactory {
                 .clientId(clientId)
                 .proposedBidAmount(1000)
                 .coverLetter("Test cover letter")
+                .proposalStatus(ProposalStatus.SUBMITTED)  // <-- Add this
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();


### PR DESCRIPTION
Added a GET mapping to retrieve proposals for a specific job posting ID. Only proposals with the status 'Submitted' are retrieved

OUTPUT:-
{
    "jobPostingId": 21,
    "freelancerId": "b400bdb6-5e2e-4655-82ca-d6c130ea5c8f",
    "clientId": "425041e0-6621-4760-b11b-a0caa2d18953",
    "proposedBidAmount": 5000,
    "proposalStatus": "SUBMITTED",
    "coverLetter": "I am excited to work on this project and bring my expertise to deliver high-quality results."
}