### PR TITLE
JMK_110: add logic to answer questions added by the client in job post

### DIFF
--- a/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/controller/ProposalController.java
@@ -28,9 +28,9 @@ public class ProposalController {
     }
 
     @PostMapping("/create_proposal")
-    public ResponseEntity<ProposalSubmission> submitProposal(
+    public ResponseEntity<ProposalSubmissionDTO> submitProposal(
             @Valid @RequestBody ProposalSubmissionDTO proposalRequest) {
-        ProposalSubmission savedProposal = proposalService.submitProposal(proposalRequest);
+        ProposalSubmissionDTO savedProposal = proposalService.submitProposal(proposalRequest);
         return new ResponseEntity<>(savedProposal, HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalQuestionAnswerDTO.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalQuestionAnswerDTO.java
@@ -1,0 +1,12 @@
+package com.jobmatrix.jm_proposal.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProposalQuestionAnswerDTO {
+    private Long questionId;
+    private String answer;
+}

--- a/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalSubmissionDTO.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/dto/ProposalSubmissionDTO.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.*;
+
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -34,4 +36,5 @@ public class ProposalSubmissionDTO {
     @NotBlank(message = "Cover letter is required")
     private String coverLetter;
 
+    private List<ProposalQuestionAnswerDTO> questionAnswers;
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalQuestionAnswer.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalQuestionAnswer.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
+import com.common.entity.JobPostingQuestion;
 
 @Data
 @Builder(toBuilder = true)
@@ -22,8 +23,9 @@ public class ProposalQuestionAnswer {
     @JoinColumn(name = "proposal_id", nullable = false)
     private ProposalSubmission proposalSubmission;
 
-    @Column(name = "question_id", nullable = false)
-    private Long questionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private JobPostingQuestion jobPostingQuestion;
 
     @Column(name = "answer", nullable = false, columnDefinition = "TEXT")
     private String answer;

--- a/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalQuestionAnswer.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalQuestionAnswer.java
@@ -1,0 +1,38 @@
+package com.jobmatrix.jm_proposal.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "proposal_question_answer")
+public class ProposalQuestionAnswer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "answer_id")
+    private Long answerId;
+
+    @ManyToOne
+    @JoinColumn(name = "proposal_id", nullable = false)
+    private ProposalSubmission proposalSubmission;
+
+    @Column(name = "question_id", nullable = false)
+    private Long questionId;
+
+    @Column(name = "answer", nullable = false, columnDefinition = "TEXT")
+    private String answer;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.JdbcType;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.dialect.PostgreSQLEnumJdbcType;
@@ -56,5 +57,7 @@ public class ProposalSubmission {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @OneToMany(mappedBy = "proposalSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProposalQuestionAnswer> questionAnswers;
 
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/entity/ProposalSubmission.java
@@ -57,7 +57,7 @@ public class ProposalSubmission {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "proposalSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "proposalSubmission", orphanRemoval = true)
     private List<ProposalQuestionAnswer> questionAnswers;
 
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/AnswerTooLongException.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/AnswerTooLongException.java
@@ -1,0 +1,7 @@
+package com.jobmatrix.jm_proposal.exception;
+
+public class AnswerTooLongException extends RuntimeException {
+    public AnswerTooLongException(int maxWordLimit) {
+        super("Answer exceeds " + maxWordLimit + " word limit.");
+    }
+}

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/AnswerTooLongException.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/AnswerTooLongException.java
@@ -1,7 +1,7 @@
 package com.jobmatrix.jm_proposal.exception;
 
 public class AnswerTooLongException extends RuntimeException {
-    public AnswerTooLongException(int maxWordLimit) {
-        super("Answer exceeds " + maxWordLimit + " word limit.");
+    public AnswerTooLongException(int maxCharLimit) {
+        super("Answer exceeds " + maxCharLimit + " char limit.");
     }
 }

--- a/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandler.java
@@ -38,4 +38,8 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(AnswerTooLongException.class)
+    public ResponseEntity<String> handleAnswerTooLongException(AnswerTooLongException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
+}

--- a/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/service/ProposalService.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public interface ProposalService {
-    ProposalSubmission submitProposal(ProposalSubmissionDTO proposalRequest);
+    ProposalSubmissionDTO submitProposal(ProposalSubmissionDTO proposalRequest);
 
     Map<ProposalStatus, List<ProposalSubmissionDTO>> getProposalsByStatus(UUID freelancerId, List<ProposalStatus> statusList);
     List<ProposalSubmissionDTO> getProposalsByJobPostingId(Long jobPostingId);

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -26,21 +26,21 @@ public class ProposalServiceImpl implements ProposalService {
     private final FreelancerRepository freelancerRepository;
     private final ModelMapper modelMapper;
 
+    private static final int maxCharLimit = 5000;
     @Override
     @Transactional
     public ProposalSubmissionDTO submitProposal(ProposalSubmissionDTO proposalRequest) {
         ProposalSubmission proposal = modelMapper.map(proposalRequest, ProposalSubmission.class);
         proposal.setProposalId(null);
         // Map answers manually and set back-reference
-        int maxWordLimit = 200;
         List<ProposalQuestionAnswerDTO> answerDTOs = proposalRequest.getQuestionAnswers();
         if (answerDTOs != null && !answerDTOs.isEmpty()) {
             for (ProposalQuestionAnswerDTO dto : answerDTOs) {
                 String answerText = dto.getAnswer();
                 if (answerText != null) {
-                    int wordCount = answerText.trim().split("\\s+").length;
-                    if (wordCount > maxWordLimit) {
-                        throw new AnswerTooLongException(maxWordLimit);
+                    int wordCount = answerText.trim().length();
+                    if (wordCount > maxCharLimit) {
+                        throw new AnswerTooLongException(maxCharLimit);
                     }
                 }
             }

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -27,7 +27,7 @@ public class ProposalServiceImpl implements ProposalService {
     private final FreelancerRepository freelancerRepository;
     private final ModelMapper modelMapper;
 
-    private static final int maxCharLimit = 5000;
+    private static final int MAX_CHAR_LIMIT = 5000;
     @Override
     @Transactional
     public ProposalSubmissionDTO submitProposal(ProposalSubmissionDTO proposalRequest) {
@@ -37,13 +37,7 @@ public class ProposalServiceImpl implements ProposalService {
         List<ProposalQuestionAnswerDTO> answerDTOs = proposalRequest.getQuestionAnswers();
         if (answerDTOs != null && !answerDTOs.isEmpty()) {
             for (ProposalQuestionAnswerDTO dto : answerDTOs) {
-                String answerText = dto.getAnswer();
-                if (answerText != null) {
-                    int charCount = answerText.trim().length();
-                    if (charCount > maxCharLimit) {
-                        throw new AnswerTooLongException(maxCharLimit);
-                    }
-                }
+                validateAnswerLength(dto.getAnswer());
             }
             List<ProposalQuestionAnswer> answers = answerDTOs.stream()
                     .map(dto -> {
@@ -72,6 +66,14 @@ public class ProposalServiceImpl implements ProposalService {
             dto.setQuestionAnswers(answerDTOs);
         }
         return dto;
+    }
+    private void validateAnswerLength(String answer) {
+        if (answer != null) {
+            int charCount = answer.trim().length();
+            if (charCount > MAX_CHAR_LIMIT) {
+                throw new AnswerTooLongException(MAX_CHAR_LIMIT);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -2,8 +2,11 @@ package com.jobmatrix.jm_proposal.serviceimpl;
 
 import com.common.enums.ProposalStatus;
 import com.common.exceptionHandling.FreelancerNotFoundException;
+import com.jobmatrix.jm_proposal.dto.ProposalQuestionAnswerDTO;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
+import com.jobmatrix.jm_proposal.entity.ProposalQuestionAnswer;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
+import com.jobmatrix.jm_proposal.exception.AnswerTooLongException;
 import com.jobmatrix.jm_proposal.repository.FreelancerRepository;
 import com.jobmatrix.jm_proposal.repository.ProposalRepository;
 import com.jobmatrix.jm_proposal.service.ProposalService;
@@ -25,10 +28,46 @@ public class ProposalServiceImpl implements ProposalService {
 
     @Override
     @Transactional
-    public ProposalSubmission submitProposal(ProposalSubmissionDTO proposalRequest) {
+    public ProposalSubmissionDTO submitProposal(ProposalSubmissionDTO proposalRequest) {
         ProposalSubmission proposal = modelMapper.map(proposalRequest, ProposalSubmission.class);
         proposal.setProposalId(null);
-        return proposalRepository.save(proposal);
+        // Map answers manually and set back-reference
+        int maxWordLimit = 200;
+        List<ProposalQuestionAnswerDTO> answerDTOs = proposalRequest.getQuestionAnswers();
+        if (answerDTOs != null && !answerDTOs.isEmpty()) {
+            for (ProposalQuestionAnswerDTO dto : answerDTOs) {
+                String answerText = dto.getAnswer();
+                if (answerText != null) {
+                    int wordCount = answerText.trim().split("\\s+").length;
+                    if (wordCount > maxWordLimit) {
+                        throw new AnswerTooLongException(maxWordLimit);
+                    }
+                }
+            }
+            List<ProposalQuestionAnswer> answers = answerDTOs.stream()
+                    .map(dto -> {
+                        ProposalQuestionAnswer answer = modelMapper.map(dto, ProposalQuestionAnswer.class);
+                        answer.setAnswerId(null);
+                        answer.setProposalSubmission(proposal);
+                        return answer;
+                    }).toList();
+            proposal.setQuestionAnswers(answers);
+        }
+        ProposalSubmission savedProposal = proposalRepository.save(proposal);
+        return mapToResponseDTO(savedProposal);
+    }
+    private ProposalSubmissionDTO mapToResponseDTO(ProposalSubmission proposal) {
+        ProposalSubmissionDTO dto = modelMapper.map(proposal, ProposalSubmissionDTO.class);
+        if (proposal.getQuestionAnswers() != null) {
+            List<ProposalQuestionAnswerDTO> answerDTOs = proposal.getQuestionAnswers().stream()
+                    .map(answer -> ProposalQuestionAnswerDTO.builder()
+                            .questionId(answer.getQuestionId())
+                            .answer(answer.getAnswer())
+                            .build())
+                    .toList();
+            dto.setQuestionAnswers(answerDTOs);
+        }
+        return dto;
     }
 
     @Override

--- a/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
+++ b/src/main/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jobmatrix.jm_proposal.serviceimpl;
 
+import com.common.entity.JobPostingQuestion;
 import com.common.enums.ProposalStatus;
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import com.jobmatrix.jm_proposal.dto.ProposalQuestionAnswerDTO;
@@ -38,8 +39,8 @@ public class ProposalServiceImpl implements ProposalService {
             for (ProposalQuestionAnswerDTO dto : answerDTOs) {
                 String answerText = dto.getAnswer();
                 if (answerText != null) {
-                    int wordCount = answerText.trim().length();
-                    if (wordCount > maxCharLimit) {
+                    int charCount = answerText.trim().length();
+                    if (charCount > maxCharLimit) {
                         throw new AnswerTooLongException(maxCharLimit);
                     }
                 }
@@ -49,6 +50,9 @@ public class ProposalServiceImpl implements ProposalService {
                         ProposalQuestionAnswer answer = modelMapper.map(dto, ProposalQuestionAnswer.class);
                         answer.setAnswerId(null);
                         answer.setProposalSubmission(proposal);
+                        JobPostingQuestion jobPostingQuestion = new JobPostingQuestion();
+                        jobPostingQuestion.setQuestionId(dto.getQuestionId());
+                        answer.setJobPostingQuestion(jobPostingQuestion);
                         return answer;
                     }).toList();
             proposal.setQuestionAnswers(answers);
@@ -61,7 +65,7 @@ public class ProposalServiceImpl implements ProposalService {
         if (proposal.getQuestionAnswers() != null) {
             List<ProposalQuestionAnswerDTO> answerDTOs = proposal.getQuestionAnswers().stream()
                     .map(answer -> ProposalQuestionAnswerDTO.builder()
-                            .questionId(answer.getQuestionId())
+                            .questionId(answer.getJobPostingQuestion().getQuestionId())
                             .answer(answer.getAnswer())
                             .build())
                     .toList();

--- a/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
@@ -58,9 +58,9 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleAnswerTooLongException_shouldReturnBadRequestMessage() {
-        int wordLimit = 200;
-        AnswerTooLongException exception = new AnswerTooLongException(wordLimit);
-        String expectedMessage = "Answer exceeds " + wordLimit + " word limit.";
+        int charLimit = 5000;
+        AnswerTooLongException exception = new AnswerTooLongException(charLimit);
+        String expectedMessage = "Answer exceeds " + charLimit + " char limit.";
         ResponseEntity<String> response = exceptionHandler.handleAnswerTooLongException(exception);
         assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
         assertEquals(expectedMessage, response.getBody());

--- a/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/exception/GlobalExceptionHandlerTest.java
@@ -56,4 +56,13 @@ class GlobalExceptionHandlerTest {
         assertEquals(expectedMessage, response.getBody());
     }
 
+    @Test
+    void handleAnswerTooLongException_shouldReturnBadRequestMessage() {
+        int wordLimit = 200;
+        AnswerTooLongException exception = new AnswerTooLongException(wordLimit);
+        String expectedMessage = "Answer exceeds " + wordLimit + " word limit.";
+        ResponseEntity<String> response = exceptionHandler.handleAnswerTooLongException(exception);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
+        assertEquals(expectedMessage, response.getBody());
+    }
 }

--- a/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/serviceimpl/ProposalServiceImplTest.java
@@ -4,6 +4,7 @@ import com.common.enums.ProposalStatus;
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
+import com.jobmatrix.jm_proposal.exception.AnswerTooLongException;
 import com.jobmatrix.jm_proposal.repository.FreelancerRepository;
 import com.jobmatrix.jm_proposal.repository.ProposalRepository;
 import com.jobmatrix.jm_proposal.test_utils.factory.ProposalTestDataFactory;
@@ -61,9 +62,8 @@ class ProposalServiceImplTest {
         savedProposal.setProposalId(1L);
 
         when(proposalRepository.save(any(ProposalSubmission.class))).thenReturn(savedProposal);
-        ProposalSubmission result = proposalService.submitProposal(request);
+        ProposalSubmissionDTO result = proposalService.submitProposal(request);
 
-        assertEquals(1L, result.getProposalId());
         assertEquals(request.getJobPostingId(), result.getJobPostingId());
         assertEquals(request.getFreelancerId(), result.getFreelancerId());
         assertEquals(request.getClientId(), result.getClientId());
@@ -71,6 +71,40 @@ class ProposalServiceImplTest {
         assertEquals(request.getCoverLetter(), result.getCoverLetter());
 
         verify(proposalRepository).save(any(ProposalSubmission.class));
+    }
+
+    @Test
+    void submitProposal_shouldSaveProposal_WhenAnswersAreValid() {
+        UUID freelancerId = UUID.randomUUID();
+        UUID clientId = UUID.randomUUID();
+
+        ProposalSubmissionDTO request = ProposalTestDataFactory.createProposalSubmissionRequest(freelancerId, clientId);
+        request.setQuestionAnswers(ProposalTestDataFactory.createValidAnswerDTOs());
+        ProposalSubmission savedProposal = ProposalTestDataFactory.createProposalEntity(1L, freelancerId, clientId);
+        when(proposalRepository.save(any(ProposalSubmission.class))).thenReturn(savedProposal);
+        ProposalSubmissionDTO result = proposalService.submitProposal(request);
+
+        assertEquals(request.getJobPostingId(), result.getJobPostingId());
+        assertEquals(request.getFreelancerId(), result.getFreelancerId());
+        assertEquals(request.getClientId(), result.getClientId());
+        assertEquals(request.getProposedBidAmount(), result.getProposedBidAmount());
+        assertEquals(request.getCoverLetter(), result.getCoverLetter());
+        verify(proposalRepository).save(any(ProposalSubmission.class));
+    }
+
+    @Test
+    void submitProposal_shouldThrowException_WhenAnswerExceedsWordLimit() {
+        UUID freelancerId = UUID.randomUUID();
+        UUID clientId = UUID.randomUUID();
+
+        ProposalSubmissionDTO request = ProposalTestDataFactory.createProposalSubmissionRequest(freelancerId, clientId);
+        request.setQuestionAnswers(ProposalTestDataFactory.createInvalidAnswerDTOs());
+
+        assertThrows(AnswerTooLongException.class, () -> {
+            proposalService.submitProposal(request);
+        });
+
+        verify(proposalRepository, never()).save(any(ProposalSubmission.class));
     }
 
     @Test

--- a/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
@@ -54,20 +54,34 @@ public class ProposalTestDataFactory {
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
+
     public static List<ProposalQuestionAnswerDTO> createValidAnswerDTOs() {
         return List.of(
                 ProposalQuestionAnswerDTO.builder()
                         .questionId(1L)
-                        .answer("This is a valid short answer.")
+                        .answer("This is a valid short answer to question 1.")
+                        .build(),
+                ProposalQuestionAnswerDTO.builder()
+                        .questionId(2L)
+                        .answer("This is a valid short answer to question 2.")
+                        .build(),
+                ProposalQuestionAnswerDTO.builder()
+                        .questionId(3L)
+                        .answer("Another valid answer.")
                         .build()
         );
     }
+
     public static List<ProposalQuestionAnswerDTO> createInvalidAnswerDTOs() {
         String longAnswer = String.join(" ", Collections.nCopies(201, "word"));
         return List.of(
                 ProposalQuestionAnswerDTO.builder()
                         .questionId(1L)
-                        .answer(longAnswer)
+                        .answer(longAnswer) // Too long
+                        .build(),
+                ProposalQuestionAnswerDTO.builder()
+                        .questionId(2L)
+                        .answer("") // Empty answer
                         .build()
         );
     }

--- a/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
@@ -73,7 +73,7 @@ public class ProposalTestDataFactory {
     }
 
     public static List<ProposalQuestionAnswerDTO> createInvalidAnswerDTOs() {
-        String longAnswer = String.join(" ", Collections.nCopies(201, "word"));
+        String longAnswer = "a".repeat(5001);
         return List.of(
                 ProposalQuestionAnswerDTO.builder()
                         .questionId(1L)

--- a/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/jm_proposal/test_utils/factory/ProposalTestDataFactory.java
@@ -1,11 +1,14 @@
 
 package com.jobmatrix.jm_proposal.test_utils.factory;
 
+import com.jobmatrix.jm_proposal.dto.ProposalQuestionAnswerDTO;
 import com.jobmatrix.jm_proposal.dto.ProposalSubmissionDTO;
 import com.jobmatrix.jm_proposal.entity.ProposalSubmission;
 import com.common.enums.ProposalStatus;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 public class ProposalTestDataFactory {
@@ -50,5 +53,22 @@ public class ProposalTestDataFactory {
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
+    }
+    public static List<ProposalQuestionAnswerDTO> createValidAnswerDTOs() {
+        return List.of(
+                ProposalQuestionAnswerDTO.builder()
+                        .questionId(1L)
+                        .answer("This is a valid short answer.")
+                        .build()
+        );
+    }
+    public static List<ProposalQuestionAnswerDTO> createInvalidAnswerDTOs() {
+        String longAnswer = String.join(" ", Collections.nCopies(201, "word"));
+        return List.of(
+                ProposalQuestionAnswerDTO.builder()
+                        .questionId(1L)
+                        .answer(longAnswer)
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
[JMK_110](https://punjabskillsbank.atlassian.net/jira/software/projects/JMK/boards/4?selectedIssue=JMK-110)
Added support for answering optional questions during proposal submission. Freelancers can submit answers to the questions provided in the job posting. Each answer is validated to ensure it does not exceed 200 words. If any answer exceeds the limit, an `AnswerTooLongException` is thrown.

**Request Body:**
```
{
  "jobPostingId": 39,
  "freelancerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "clientId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "proposedBidAmount": 1073741824,
  "proposalStatus": "SUBMITTED",
  "coverLetter": "string",
  "questionAnswers": [
    {
      "questionId": 1,
      "answer": "string"
    }
  ]
}
```

**Response Body:**
```
{
  "jobPostingId": 39,
  "freelancerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "clientId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "proposedBidAmount": 1073741824,
  "proposalStatus": "SUBMITTED",
  "coverLetter": "string",
  "questionAnswers": [
    {
      "questionId": 1,
      "answer": "string"
    }
  ]
}
```